### PR TITLE
Information gain changes for Attribution Scope

### DIFF
--- a/attribution_scopes.md
+++ b/attribution_scopes.md
@@ -58,7 +58,7 @@ The following optional parameters will be added to the JSON in `Attribution-Repo
   // Example: default event source for event-level reports supports 1 attribution report, 1 reporting window,
   // and 1 bit of trigger data for a total of 3 event states.
   // This is used to calculate the information gain for event-level reports.
-  // Max event states must be integers > 0.
+  // Max event states must be positive integers.
   // Defaults to 3 if omitted.
   // The flexible event-level script linked in the Privacy Considerations section below can be used to
   // calculate number of states based on a configuration.
@@ -76,8 +76,7 @@ The following optional parameter will be added to the JSON in  `Attribution-Repo
   // Represents a list of attribution scopes for a particular trigger.
   // Triggers will only match sources whose attribution_scopes contains at least one of the trigger's
   // attribution_scopes, if specified.
-  // Attribution scope values must be strings. Each string has a maximum length of 50.
-  // Each list has a maximum length of 20.
+  // Attribution scope values must be strings.
   // Defaults to the empty list if omitted.
   "attribution_scopes": <list of strings>,
 }

--- a/flexible_event_config.md
+++ b/flexible_event_config.md
@@ -76,11 +76,11 @@ In addition to the parameters that were added in Phase 1, we will add one additi
       "end_times": [<int>, ...],
     }
 
-    // Represents an operator that summarizes the triggers within a window
-    // count: number of triggers attributed within a window
-    // value_sum: sum of the value of triggers within a window
+    // Represents an operator that summarizes the triggers attributed to the source.
+    // count: number of triggers attributed
+    // value_sum: sum of the value of triggers
     // Defaults to "count"
-    "summary_window_operator": <one of "count" or "value_sum">,
+    "summary_operator": <one of "count" or "value_sum">,
 
     // Represents a bucketization of the integers from [0, MAX_UINT32], encoded as
     // a list of integers where new buckets begin (excluding 0 which is
@@ -150,7 +150,7 @@ Every trigger registration will match with at most one trigger spec and update i
 * For every trigger spec:
   * Evaluate the `event_trigger_data` on the spec to find a match, using the spec’s `event_reporting_window`
     * The top-level `event_reporting_windows` will act as a default value in case any trigger spec is the missing `event_report_windows` sub-field
-* The first matched spec is chosen for attribution, and we increment its summary value by `value` if the spec's `summary_window_operator` is `value_sum`, or by `1` if it is `count`, saturating in both cases at `MAX_UINT32`.
+* The first matched spec is chosen for attribution, and we increment its summary value by `value` if the spec's `summary_operator` is `value_sum`, or by `1` if it is `count`, saturating in both cases at `MAX_UINT32`.
 
 When the `event_report_window` for a spec completes, we will map its summary value to a bucket, and send an event-level report for every increment in the summary bucket caused by attributed trigger values. Reports will come with one extra field `trigger_summary_bucket`.
 
@@ -223,7 +223,7 @@ It is possible that there are multiple configurations that are equivalent, given
     "event_report_windows": {
       "end_times": [<30 days>]
     },
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1]
   }],
   "max_event_level_reports": 1,
@@ -244,7 +244,7 @@ It is possible that there are multiple configurations that are equivalent, given
     "event_report_windows": {
       "end_times": [<2 days>, <7 days>, <30 days>]
     },
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1, 2, 3]
   }],
   "max_event_level_reports": 3,
@@ -272,7 +272,7 @@ This example configuration supports a developer who wants to optimize for value 
     "event_report_windows": {
       "end_times": [604800, 1209600] // 7 days, 14 days represented in seconds
     },
-    "summary_window_operator": "value_sum",
+    "summary_operator": "value_sum",
     "summary_buckets": [5, 10, 100]
   }],
 }
@@ -333,13 +333,13 @@ This example shows how a developer can configure a source to get a count of trig
       "end_times": [604800] // 7 days represented in seconds
     },
     // This field could be omitted to save bandwidth since the default is "count"
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1, 2, 3, 4]
   }],
 }
 ```
 
-Attributed triggers with `trigger_data` set to 0 are counted and capped at 4. The trigger value is ignored since `summary_window_operator` is set to `count`. Supposing 4 triggers are registered and attributed to the source, the reports would look like this:
+Attributed triggers with `trigger_data` set to 0 are counted and capped at 4. The trigger value is ignored since `summary_operator` is set to `count`. Supposing 4 triggers are registered and attributed to the source, the reports would look like this:
 
 ```jsonc
 // Report 1
@@ -379,7 +379,7 @@ This example configuration supports a developer who wants to learn whether at le
       "end_times": [86400, 172800, 259200, 432000, 604800, 864000]
     },
     // This field could be omitted to save bandwidth since the default is "count"
-    "summary_window_operator": "count",
+    "summary_operator": "count",
     "summary_buckets": [1]
   }],
 }

--- a/index.bs
+++ b/index.bs
@@ -680,12 +680,12 @@ Note: The [=report window list/total window=] is conceptually a union of
 [=report windows=], because there are no gaps in time between any of the
 [=report windows|windows=].
 
-<h3 id="summary-windows-operator-header">Summary window operator</h3>
+<h3 id="summary-operator-header">Summary operator</h3>
 
-A <dfn>summary window operator</dfn> summarizes the triggers within a
-[=report window=]. Its value is one of the following:
+A <dfn>summary operator</dfn> summarizes the triggers attributed to an
+[=attribution source=]. Its value is one of the following:
 
-<dl dfn-for="summary window operator">
+<dl dfn-for="summary operator">
 : "<dfn><code>count</code></dfn>"
 :: Number of triggers attributed.
 : "<dfn><code>value_sum</code></dfn>"
@@ -2416,7 +2416,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>source_event_id</code></dfn>"
 <li>"<dfn><code>start_time</code></dfn>"
 <li>"<dfn><code>summary_buckets</code></dfn>"
-<li>"<dfn><code>summary_window_operator</code></dfn>"
+<li>"<dfn><code>summary_operator</code></dfn>"
 <li>"<dfn><code>trigger_data</code></dfn>"
 <li>"<dfn><code>trigger_data_matching</code></dfn>"
 <li>"<dfn><code>trigger_specs</code></dfn>"
@@ -2561,15 +2561,15 @@ non-normative behavior described in the
 <a href="https://github.com/WICG/attribution-reporting-api/blob/main/flexible_event_config.md">Flexible event-level configurations</a>
 proposal.
 
-To <dfn>parse summary window operator</dfn> given a [=map=] |map|:
+To <dfn>parse summary operator</dfn> given a [=map=] |map|:
 
-1. Let |value| be "<code>[=summary window operator/count=]</code>".
-1. If |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"] [=map/exists=]:
-    1. If |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"] is not a [=string=], return an
+1. Let |value| be "<code>[=summary operator/count=]</code>".
+1. If |map|["<code>[=source-registration JSON key/summary_operator=]</code>"] [=map/exists=]:
+    1. If |map|["<code>[=source-registration JSON key/summary_operator=]</code>"] is not a [=string=], return an
         error.
-    1. If |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"] is not a
-        [=summary window operator=], return an error.
-    1. Set |value| to |map|["<code>[=source-registration JSON key/summary_window_operator=]</code>"].
+    1. If |map|["<code>[=source-registration JSON key/summary_operator=]</code>"] is not a
+        [=summary operator=], return an error.
+    1. Set |value| to |map|["<code>[=source-registration JSON key/summary_operator=]</code>"].
 1. Return |value|.
 
 To <dfn>parse summary buckets</dfn> given a [=map=] |map| and an integer |maxEventLevelReports|:
@@ -2669,7 +2669,7 @@ To <dfn>parse trigger specs</dfn> given a [=map=] |map|, a [=moment=]
         1. Set |i| to |i| + 1.
 1. Return |specs|.
 
-Issue: Invoke [=parse summary buckets=] and [=parse summary window operator=]
+Issue: Invoke [=parse summary buckets=] and [=parse summary operator=]
 from this algorithm.
 
 To <dfn>parse a source aggregatable debug reporting config</dfn> given |value|, a

--- a/index.bs
+++ b/index.bs
@@ -845,6 +845,12 @@ An attribution source is a [=struct=] with the following items:
 :: An [=aggregatable debug reporting config=].
 : <dfn>destination limit priority</dfn>
 :: A 64-bit integer.
+: <dfn>attribution scope limit</dfn>
+:: Null or a positive 32-bit integer representing the number of distinct [=attribution source/attribution scopes=] allowed per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
+: <dfn>attribution scopes</dfn>
+:: A [=set=] of [=strings=].
+: <dfn>max event states</dfn>
+:: A positive integer representing the maximum number of [=trigger states=] for [=source type/event=] sources per [=attribution source/attribution destinations|attribution destination=] for the source's [=attribution source/reporting origin=].
 
 </dl>
 
@@ -985,6 +991,8 @@ An attribution trigger is a [=struct=] with the following items:
 :: A positive integer.
 : <dfn>aggregatable debug reporting config</dfn>
 :: An [=aggregatable debug reporting config=].
+: <dfn>attribution scopes</dfn>
+:: A [=set=] of [=strings=].
 
 </dl>
 
@@ -1413,6 +1421,17 @@ per [=aggregatable debug rate-limit window=]. The second controls the total
 [=aggregatable debug report/required aggregatable budget=] of all [=aggregatable debug reports=]
 with a given ([=aggregatable debug rate-limit record/context site=], [=aggregatable debug rate-limit record/reporting site=])
 per [=aggregatable debug rate-limit window=]. Its value is (2<sup>20</sup>, 65536).
+
+<dfn>Default max event states</dfn> is a positive integer that controls the
+default [=attribution source/max event states=]. Its value is 3.
+
+<dfn>Max length of attribution scope for source</dfn> is a positive integer that controls the
+maximum [=string/length=] of an attribution scope from an [=attribution source=]'s [=attribution source/attribution scopes=].
+Its value is 50.
+
+<dfn>Max attribution scopes per source</dfn> is a positive integer that controls the
+maximum [=set/size=] of an [=attribution source=]'s [=attribution source/attribution scopes=].
+Its value is 20.
 
 # Vendor-Specific Values # {#vendor-specific-values}
 
@@ -2401,6 +2420,8 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>aggregatable_report_window</code></dfn>"
 <li>"<dfn><code>aggregation_keys</code></dfn>"
 <li>"<dfn><code>budget</code></dfn>"
+<li>"<dfn><code>attribution_scope_limit</code></dfn>"
+<li>"<dfn><code>attribution_scopes</code></dfn>"
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>destination</code></dfn>"
@@ -2412,6 +2433,7 @@ A <dfn>source-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>expiry</code></dfn>"
 <li>"<dfn><code>filter_data</code></dfn>"
 <li>"<dfn><code>max_event_level_reports</code></dfn>"
+<li>"<dfn><code>max_event_states</code></dfn>"
 <li>"<dfn><code>priority</code></dfn>"
 <li>"<dfn><code>source_event_id</code></dfn>"
 <li>"<dfn><code>start_time</code></dfn>"
@@ -2687,6 +2709,36 @@ non-negative integer |defaultBudget|, and an [=aggregatable debug reporting conf
     with |value|, |budget|, |supportedTypes|, and |defaultConfig|.
 1. Return the [=tuple=] (|budget|, |config|).
 
+To <dfn>parse max event states</dfn> from a [=map=] |map| and
+a possibly null 32-bit positive integer |attributionScopeLimit|:
+1. Let |maxEventStates| be [=default max event states=].
+1. If |map|["<code>[=source-registration JSON key/max_event_states=]</code>"] [=map/exists=], set |maxEventStates| to |map|["<code>[=source-registration JSON key/max_event_states=]</code>"].
+1. If |maxEventStates| is not an integer or is less than or equal to 0, return an error.
+1. If |maxEventStates| is greater than the user agent's [=max trigger-state cardinality=], return an error.
+1. If |maxEventStates| is not equal to [=default max event states=] and |attributionScopeLimit| is null, return an error.
+1. Return |maxEventStates|.
+
+To <dfn>parse attribution scopes for source</dfn> from a [=map=] |map| and a possibly null 32-bit positive integer |attributionScopeLimit|:
+1. Let |result| be a new [=set=].
+1. If |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return |result|.
+1. Let |values| be |map|["<code>[=source-registration JSON key/attribution_scopes=]</code>"].
+1. If |values| is not a [=list=], return an error.
+1. [=list/iterate|For each=] |value| of |values|:
+    1. If |value| is not a [=string=], return an error.
+    1. If |value|'s [=string/length=] is greater than [=max length of attribution scope for source=], return an error.
+    1. [=set/Append=] |value| to |result|.
+1. If |attributionScopeLimit| is null:
+    1. If |result| is not [=set/is empty|empty=], return an error.
+    1. Return |result|.
+1. If |result| [=set/is empty=], return an error.
+1. If |result|'s [=set/size=] is greater than |attributionScopeLimit|, return an error.
+1. If |result|'s [=set/size=] is greater than [=max attribution scopes per source=], return an error.
+1. Return |result|.
+
+Note: Empty attribution scopes are not allowed if |attributionScopeLimit| is set,
+to prevent the selection of both sources with and without scopes, which would effectively
+result in |attributionScopeLimit| + 1 scopes.
+
 To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 |json|, a [=suitable origin=] |sourceOrigin|, a [=suitable origin=] |reportingOrigin|, a
 [=source type=] |sourceType|, a [=moment=] |sourceTime|, and a [=boolean=] |fenced|:
@@ -2756,6 +2808,15 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
 1. Let |triggerSpecs| be the result of [=parsing trigger specs=] with |value|,
     |sourceTime|, |sourceType|, |expiry|, and |triggerDataMatchingMode|.
 1. If |triggerSpecs| is an error, return null.
+1. Let |attributionScopeLimit| be null.
+1. If |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"] [=map/exists=]:
+    1. Set |attributionScopeLimit| to |value|["<code>[=source-registration JSON key/attribution_scope_limit=]</code>"].
+    1. If |attributionScopeLimit| is not an integer, cannot be represented by an unsigned 32-bit integer, or is less than or equal to zero, return null.
+1. Let |maxEventStates| be the result of running
+    [=parse max event states=] with |value| and |attributionScopeLimit|.
+1. If |maxEventStates| is an error, return null.
+1. Let |attributionScopes| be the result of running [=parse attribution scopes for source=] with |value| and |attributionScopeLimit|.
+1. If |attributionScopes| is an error, return null.
 1. Let |epsilon| be the user agent's [=max settable event-level epsilon=].
 1. Set |epsilon| to |value|["<code>[=source-registration JSON key/event_level_epsilon=]</code>"] if it [=map/exists=]:
 1. If |epsilon| is not a double, is less than 0, or is greater than the user agent's [=max settable event-level epsilon=], return null.
@@ -2822,6 +2883,12 @@ To <dfn noexport>parse source-registration JSON</dfn> given a [=byte sequence=]
     :: |aggregatableDebugReportingConfig|
     : [=attribution source/destination limit priority=]
     :: |destinationLimitPriority|
+    : [=attribution source/attribution scopes=]
+    :: |attributionScopes|
+    : [=attribution source/attribution scope limit=]
+    :: |attributionScopeLimit|
+    : [=attribution source/max event states=]
+    :: |maxEventStates|
 1. Return |source|.
 
 Issue: Determine proper charset-handling for the JSON header value.
@@ -3296,6 +3363,7 @@ A <dfn>trigger-registration JSON key</dfn> is one of the following:
 <li>"<dfn><code>aggregatable_trigger_data</code></dfn>"
 <li>"<dfn><code>aggregatable_values</code></dfn>"
 <li>"<dfn><code>aggregation_coordinator_origin</code></dfn>"
+<li>"<dfn><code>attribution_scopes</code></dfn>"
 <li>"<dfn><code>debug_key</code></dfn>"
 <li>"<dfn><code>debug_reporting</code></dfn>"
 <li>"<dfn><code>deduplication_key</code></dfn>"
@@ -3511,6 +3579,16 @@ To <dfn>parse aggregatable dedup keys</dfn> given a [=map=] |map|:
     1. [=set/Append=] |aggregatableDedupKey| to |aggregatableDedupKeys|.
 1. Return |aggregatableDedupKeys|.
 
+To <dfn>parse attribution scopes for trigger</dfn> from a [=map=] |map|:
+1. Let |result| be a new [=set=].
+1. If |map|["<code>[=trigger-registration JSON key/attribution_scopes=]</code>"] does not [=map/exist=], return |result|.
+1. Let |values| be |map|["<code>[=trigger-registration JSON key/attribution_scopes=]</code>"].
+1. If |values| is not a [=list=], return an error.
+1. [=list/iterate|For each=] |value| of |values|:
+    1. If |value| is not a [=string=], return an error.
+    1. [=set/Append=] |value| to |result|.
+1. Return |result|.
+
 To <dfn noexport>create an attribution trigger</dfn> given a [=byte sequence=]
 |json|, a [=site=] |destination|, a [=suitable origin=] |reportingOrigin|, a [=list=] of [=trigger verification=] |triggerVerifications|,
 a [=moment=] |triggerTime|, and a [=boolean=] |fenced|:
@@ -3566,6 +3644,8 @@ a [=moment=] |triggerTime|, and a [=boolean=] |fenced|:
     1. Set |aggregatableDebugReportingConfig| to the result of running [=parse an aggregatable debug reporting config=]
         with |value|["<code>[=trigger-registration JSON key/aggregatable_debug_reporting=]</code>"],
         [=allowed aggregatable budget per source=], |supportedTypes|, and |aggregatableDebugReportingConfig|.
+1. Let |attributionScopes| be the result of running [=parse attribution scopes for trigger=] with |value|.
+1. If |attributionScopes| is an error, return null.
 1. Let |trigger| be a new [=attribution trigger=] with the items:
     : [=attribution trigger/attribution destination=]
     :: |destination|
@@ -3603,6 +3683,8 @@ a [=moment=] |triggerTime|, and a [=boolean=] |fenced|:
     :: |filteringIdsMaxBytes|
     : [=attribution trigger/aggregatable debug reporting config=]
     :: |aggregatableDebugReportingConfig|
+    : [=attribution trigger/attribution scopes=]
+    :: |attributionScopes|
 1. If |aggregatableSourceRegTimeConfig| is not "<code>[=aggregatable source registration time configuration/exclude=]</code>"
     and the result of running [=check if an aggregatable attribution report should be unconditionally sent=] with |trigger| is true, return null.
 1. Return |trigger|.

--- a/index.bs
+++ b/index.bs
@@ -3943,6 +3943,25 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
 1. Let |report| be the result of running [=obtain an event-level report=] with |sourceToAttribute|,
     |trigger|'s [=attribution trigger/trigger time=], |trigger|'s [=attribution trigger/debug key=],
     |matchedConfig|'s [=event-level trigger configuration/priority=], and |specEntry|.
+1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
+    is false:
+     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+         ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
+1. If the result of running [=maybe replace event-level report=] with |sourceToAttribute| and |report| is:
+    <dl class="switch">
+    : "<code>[=event-level-report-replacement result/add-new-report=]</code>"
+    ::
+         1. Do nothing.
+    : "<code>[=event-level-report-replacement result/drop-new-report-none-to-replace=]</code>"
+    ::
+         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+             ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
+    : "<code>[=event-level-report-replacement result/drop-new-report-low-priority=]</code>"
+    ::
+         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+             ("<code>[=trigger debug data type/trigger-event-low-priority=]</code>", |report|)).
+
+    </dl>
 1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
     : [=attribution rate-limit record/scope=]
     :: "<code>[=rate-limit scope/event-attribution=]</code>"
@@ -3960,29 +3979,11 @@ To <dfn>trigger event-level attribution</dfn> given an [=attribution trigger=] |
     :: |report|'s [=event-level report/report ID=]
 1. If the result of running [=check if attribution should be blocked by rate limits=]
     with |trigger|, |sourceToAttribute|, and |rateLimitRecord| is not null, return it.
-1. If |sourceToAttribute|'s [=attribution source/event-level attributable=] value
-    is false:
-     1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-         ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
-1. If the result of running [=maybe replace event-level report=] with |sourceToAttribute| and |report| is:
-    <dl class="switch">
-    : "<code>[=event-level-report-replacement result/add-new-report=]</code>"
-    ::
-         1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
-             [=event-level report/attribution destinations=] [=set/contains=] |trigger|'s [=attribution trigger/attribution destination=].
-         1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=]:
-             1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-                 ("<code>[=trigger debug data type/trigger-event-storage-limit=]</code>", null)).
-    : "<code>[=event-level-report-replacement result/drop-new-report-none-to-replace=]</code>"
-    ::
-         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-             ("<code>[=trigger debug data type/trigger-event-excessive-reports=]</code>", |report|)).
-    : "<code>[=event-level-report-replacement result/drop-new-report-low-priority=]</code>"
-    ::
-         1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
-             ("<code>[=trigger debug data type/trigger-event-low-priority=]</code>", |report|)).
-
-    </dl>
+1. Let |numMatchingReports| be the number of entries in the [=event-level report cache=] whose
+    [=event-level report/attribution destinations=] [=set/contains=] |trigger|'s [=attribution trigger/attribution destination=].
+1. If |numMatchingReports| is greater than or equal to the user agent's [=max event-level reports per attribution destination=]:
+    1. Return the [=triggering result=] ("<code>[=triggering status/dropped=]</code>",
+        ("<code>[=trigger debug data type/trigger-event-storage-limit=]</code>", null)).
 1. Let |triggeringStatus| be "<code>[=triggering status/attributed=]</code>".
 1. Let |debugData| be null.
 1. If |sourceToAttribute|'s [=attribution source/randomized response=] is:

--- a/index.bs
+++ b/index.bs
@@ -2890,6 +2890,14 @@ To <dfn>delete sources for unexpired destination limit</dfn> given a [=set=] of
         and |report|'s [=event-level report/trigger time=] is greater than or equal to |now|:
         1. [=set/Append=] |report|'s [=event-level report/report ID=] to |deletedEventLevelReports|.
         1. [=set/Remove=] |report| from the [=event-level report cache=].
+
+    Note: Leaking browsing history of destinations deactivated for unexpired
+    destination limit from [=event-level reports=] whose [=event-level report/trigger time=]
+    is earlier than |now| is mitigated by the presence of [=obtain a fake report|fake reports=].
+    [=Event-level reports=] whose [=event-level report/trigger time=] is greater
+    than or equal to |now| must be deleted to avoid exposing whether an
+    [=attribution source=] has a [=attribution source/randomized response=].
+
 1. Let |deletedAggregatableReports| be a new [=set=].
 1. [=set/iterate|For each=] [=aggregatable attribution report=] |report| of the [=aggregatable attribution report cache=]:
     1. If |sourcesToDelete| [=set/contains=] |report|'s [=aggregatable attribution report/source identifier=]:

--- a/index.bs
+++ b/index.bs
@@ -2392,6 +2392,11 @@ To <dfn>obtain a randomized source response pick rate</dfn> given a [=randomized
 1. Let |numPossibleValues| be the [=set/size=] of |possibleValues|.
 1. Return |numPossibleValues| / (|numPossibleValues| - 1 + e<sup>|epsilon|</sup>).
 
+To <dfn>obtain pick rate for a source</dfn> given a positive integer |numTriggerStates|, a positive integer |numEventStates|, a non-negative 32-bit integer |numUsedScopes|, and a double |epsilon|:
+1. Let |pickRateForSource| be (|numTriggerStates| - 1) / (|numTriggerStates| - 1 + e<sup>|epsilon|</sup>).
+1. Let |pickRateForEvent| be (|numEventStates| - 1) / (|numEventStates| - 1 + e<sup>|epsilon|</sup>).
+1. Return 1 - (1 - |pickRateForSource|) * (1 - |pickRateForEvent|)<sup>|numUsedScopes|</sup>.
+
 To <dfn>obtain a randomized source response</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
 
 1. Let |possibleValues| be the result of [=obtaining a set of possible trigger states=] with |config|.
@@ -2401,13 +2406,26 @@ To <dfn>obtain a randomized source response</dfn> given a [=randomized response 
 
 <h3 algorithm id="computing-channel-capacity">Computing channel capacity</h3>
 
-To <dfn>compute the channel capacity of a source</dfn> given a [=randomized response output configuration=] |config| and a double |epsilon|:
-1. Let |pickRate| be the [=obtain a randomized source response pick rate|randomized response pick rate=] with |config| and |epsilon|.
-1. Let |states| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
-1. If |states| is 1, return 0.
-1. If |states| is greater than the user agent's [=max trigger-state cardinality=], return an error.
-1. Let |p| be |pickRate| * (|states| - 1) / |states|.
-1. Return log2(|states|) - h(|p|) - |p| * log2(|states| - 1) where h is the binary entropy function [[BIN-ENT]].
+To <dfn>compute the channel capacity of a source</dfn> given a [=randomized response output configuration=] |config|, a double |epsilon|, a possibly null positive 32-bit integer |attributionScopeLimit|, and a positive integer |maxEventStates|:
+1. If |attributionScopeLimit| is null, set |attributionScopeLimit| to 1.
+1. Let |numTriggerStates| be the [=obtain a set of possible trigger states|number of possible trigger states=] with |config|.
+1. If |numTriggerStates| is greater than the user agent's [=max trigger-state cardinality=], return an error.
+1. Let |maxInformationGain| be 0.
+1. [=set/iterate|For each=] integer |numUsedScopes| of [=the exclusive range|the range=] 0 to |attributionScopeLimit|, exclusive:
+    1. [=set/iterate|For each=] integer |numEventStates| of [=the range=] 1 to |maxEventStates|, inclusive:
+        1. Let |informationGain| be the [=compute information gain|information gain=] with |numTriggerStates|, |epsilon|, |numUsedScopes|, and |numEventStates|.
+        1. If |informationGain| is greater than |maxInformationGain|, set |maxInformationGain| to |informationGain|.
+1. Return |maxInformationGain|.
+
+Note: This algorithm can be optimized by performing binary search on the |numUsedScopes| or |numEventStates| dimension.
+For a given |numUsedScopes| or |numEventStates|, the [=compute information gain=] algorithm satisfies the following condition:
+for some value m, it is strictly increasing for x ≤ m and strictly decreasing for x ≥ m.
+
+To <dfn>compute information gain</dfn> given a positive integer |numTriggerStates|, a double |epsilon|, a non-negative 32-bit integer |numUsedScopes|, and a positive integer |numEventStates|:
+1. Let |totalStates| be |numTriggerStates| + |numUsedScopes| * |numEventStates|.
+1. If |totalStates| is 1, return 0.
+1. Let |p| be the result of running [=obtain pick rate for a source=] with |numTriggerStates|, |numEventStates|, |numUsedScopes|, and |epsilon|.
+1. Return log2(|totalStates|) - h(|p|) - |p| * log2(|totalStates| - 1) where h is the binary entropy function [[BIN-ENT]].
 
 Note: This algorithm computes the channel capacity [[CHAN]] of a q-ary symmetric channel [[Q-SC]].
 
@@ -3223,7 +3241,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     :: |source|'s [=trigger specs=]
 
 1. Let |epsilon| be |source|'s [=attribution source/event-level epsilon=].
-1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig| and |epsilon|.
+1. Let |channelCapacity| be the result of [=computing the channel capacity of a source=] with |randomizedResponseConfig|, |epsilon|, |source|'s [=attribution source/attribution scope limit=], and |source|'s [=attribution source/max event states=].
 1. If |channelCapacity| is an error:
     1. Run [=obtain and deliver debug reports on source registration=] with
         « "<code>[=source debug data type/source-trigger-state-cardinality-limit=]</code>" » and |source|.

--- a/meetings/2024-06-24-minutes.md
+++ b/meetings/2024-06-24-minutes.md
@@ -1,0 +1,99 @@
+# Attribution Reporting API
+
+Mon Jun 24, 2024 @ 8am PT
+
+This doc: [bit.ly/ara-meeting-notes](bit.ly/ara-meeting-notes)
+
+Meet link: [https://meet.google.com/jnn-rhxv-nsy](https://meet.google.com/jnn-rhxv-nsy)
+
+Previous meetings: [https://github.com/WICG/conversion-measurement-api/tree/main/meetings](https://github.com/WICG/conversion-measurement-api/tree/main/meetings)
+
+Meeting issue: [https://githubhttps://github.com/WICG/conversion-measurement-api/issues/80.com/WICG/conversion-measurement-api/issues/80](https://github.com/WICG/conversion-measurement-api/issues/80)
+
+
+
+* Use Google meet “Raise hand” for queuing.
+* If you can’t edit the doc during the meeting, try refreshing as permissions may have been updated after you loaded the page.
+* If you are not admitted to the meeting, try rejoining. Google Meet has some UI that makes it easy to misclick if someone simultaneously requests to join while someone else is typing into the meeting chat.
+* Please make sure to join [W3C](https://www.w3.org/) and [WICG](https://www.w3.org/community/wicg/) if you plan on participating
+
+
+# Agenda
+
+
+
+* Chair: Charlie Harrison
+* Scribe volunteer: Charlie Harrison
+
+Please suggest agenda topics here! (either in a comment or a suggestion on the doc:
+
+
+
+* Nan Lin: FIFO proposal [https://github.com/WICG/attribution-reporting-api/issues/1228](https://github.com/WICG/attribution-reporting-api/issues/1228)
+
+
+# Attendees — please sign yourself in! 
+
+(Please sign in at the start of the meeting)
+
+
+
+1. Charlie Harrison (Google Chrome)
+2. 
+3. David Dabbs (Epsilon)
+4. Michał Kalisz (RTB House)
+5. Andrew Paseltiner (Google Chrome)
+6. Nan Lin (Google Chrome)
+7. Anthony Garant (Google Chrome)
+8. Arthur Coleman (IDPrivacy)
+9. Andrew Pascoe (NextRoll)
+10. Robert Kubis (Google Chrome)
+
+
+# Notes
+
+
+## Nan Lin: FIFO proposal [https://github.com/WICG/attribution-reporting-api/issues/1228](https://github.com/WICG/attribution-reporting-api/issues/1228)
+
+
+
+* Currently we have a limit of the # of distinct destination for unexpired sources (per pub source). Once a pub registers 100 destinations, subsequent registrations will fail
+* Got feedback that this is negative impact. We would like to change this behavior to kick out old sources in favor of new sources.
+* Starting in 127, we formulate this as a priority based q so developers can prioritize, browser can keep track of registrations with higher priority. Registrations beyond this limit will be deleted
+* To mitigate history reconstruction attack, we add a new limit for the # of registrations per day.
+* Charlie: why do we need a limit?
+    * Without a limit: ad tech can keep registering new destinations. We have a per minute limit, after 30 days you can register quite a lot of destinations
+    * In the worst case in 30 days, can have 30*100 for the per-day limit (unique destinations)
+* David: specifics are in another issue (1217)
+* Nan: that’s the explainer spec change for this change
+* David: any visibility for the publisher?
+* Nan: if publisher site registers more than this, they can use this new behavior, if they want to keep the old behavior, they can use the priority field to recover the existing system
+* David: individual ad-techs that are registering sources, they can control how this works. Does the publisher get any affordance? Learn whether their advertisers are being restricted. A big site could have many hundreds of advertisers
+* Nan: currently nothing, but could consider sending debug reports to publisher site as well
+* David: understand its a “rich man’s problem”, but it’s an assumption we want to make
+* David: timeline?
+* Nan: Chrome 128. Right now it’s default disabled, but plan to enable it in M128. Backwards incompatible since we change the queue semantics
+* Charlie: Impact of the new limit?
+* Nan: don’t expect big impact since it’s the same as the existing impact
+* Charlie: Current limit is just pending impressions
+* Nan: this one is also for pending sources and also daily
+* Charlie: The way the current limit works is that we keep track of the pending impressions. That has a limit of 100. When there is a new impression. Now. from what I understand, keep that and instead if there is a 100 in storage, we’ll just kick out an old one. Always capped on 100. Per day - 100 unique destinations per day which could be more restrictive than pending because at a certain point won’t you be locked out also. Keeping a count of how many unique destinations you had today
+* Nan: the new sources will be dropped.
+* Charlie: different, now we have a system, where before you could ping-ping, flush out old impressions, but now we could be stuck by the day limit ? 
+* Nan: We only count pending sources - this new limit is strictly more restrictive. 
+* Charlie: How do we keep track ?
+* Nan: It counts all the destinations for unexpired sources within a day per publisher site per reporting site. Sources created within that day that haven’t expired yet.
+* Charlie: when would that be hit and the total one wouldn’t
+* Nan: new one is fifo, this one is lifo
+* David: you use the term “impression”. This mechanism is implying any registered source
+* Charlie: yes that’s right
+* Vikas: Just to replay. The FIFO limits is so you can monitor 100 sources at a time. LIFO limits about consuming 100 destinations a day
+
+
+## David Dabbs topic: ARA adjacent
+
+
+
+* Aggregated mechanism for private aggregation API → talk on the github. Which tree to bark up.
+* Charlie: yep that’s right.
+* David: Filtering IDs / batching Ids, etc.

--- a/ts/src/constants.ts
+++ b/ts/src/constants.ts
@@ -19,6 +19,10 @@ export const maxLengthPerAggregationKeyIdentifier: number = 25
 
 export const maxLengthPerTriggerContextID: number = 64
 
+export const maxAttributionScopesPerSource: number = 20
+
+export const maxLengthPerAttributionScope: number = 50
+
 export const minReportWindow: number = 1 * SECONDS_PER_HOUR
 
 export const validSourceExpiryRange: Readonly<[min: number, max: number]> = [
@@ -96,3 +100,5 @@ export const triggerAggregatableDebugTypes: Readonly<[string, ...string[]]> = [
   'trigger-unknown-error',
   'unspecified',
 ]
+
+export const defaultMaxEventStates: number = 3

--- a/ts/src/flexible-event/main.ts
+++ b/ts/src/flexible-event/main.ts
@@ -7,6 +7,7 @@ import { validateSource } from '../header-validator/validate-json'
 import { SourceType } from '../source-type'
 import * as vsv from '../vendor-specific-values'
 import { Config, PerTriggerDataConfig } from './privacy'
+import * as constants from '../constants'
 
 // Workaround for `parse` not handling top-level array types without `multiple`
 // `OptionDef` configuration.
@@ -25,6 +26,8 @@ function parseSourceType(str: string): SourceType {
 
 interface Arguments {
   max_event_level_reports: number
+  attribution_scope_limit: number
+  max_event_states: number
   epsilon: number
   source_type: SourceType
   windows?: Wrapped<number[]>
@@ -37,6 +40,16 @@ const options = parse<Arguments>({
     alias: 'm',
     type: Number,
     defaultValue: 20,
+  },
+  attribution_scope_limit: {
+    alias: 'a',
+    type: Number,
+    defaultValue: 1,
+  },
+  max_event_states: {
+    alias: 's',
+    type: Number,
+    defaultValue: 3,
   },
   epsilon: {
     alias: 'e',
@@ -90,6 +103,8 @@ if (options.json_file !== undefined) {
     (source) =>
       new Config(
         source.maxEventLevelReports,
+        source.attributionScopeLimit ?? 1,
+        source.maxEventStates ?? constants.defaultMaxEventStates,
         source.triggerSpecs.flatMap((spec) =>
           new Array<PerTriggerDataConfig>(spec.triggerData.size).fill(
             new PerTriggerDataConfig(
@@ -109,6 +124,8 @@ if (options.json_file !== undefined) {
   config = Maybe.some(
     new Config(
       options.max_event_level_reports,
+      options.attribution_scope_limit,
+      options.max_event_states,
       options.windows.value.map(
         (w: number, i: number) =>
           new PerTriggerDataConfig(w, options.buckets!.value[i]!)

--- a/ts/src/flexible-event/privacy.test.ts
+++ b/ts/src/flexible-event/privacy.test.ts
@@ -74,12 +74,30 @@ const infoGainTests = [
   {
     numStates: 3,
     epsilon: 14,
-    expected: 1.584926511508231,
+    expected: 1.5849265115082316,
   },
   {
     numStates: 1,
     epsilon: 14,
     expected: 0,
+  },
+  {
+    numStates: 2925,
+    epsilon: 14,
+    attributionScopeLimit: 3,
+    expected: 11.464610112285094,
+  },
+  {
+    numStates: 2925,
+    epsilon: 14,
+    attributionScopeLimit: 5,
+    expected: 11.467486215356272,
+  },
+  {
+    numStates: 2925,
+    epsilon: 14,
+    attributionScopeLimit: 100,
+    expected: 11.597577197906126,
   },
 ]
 
@@ -87,7 +105,12 @@ void test('maxInformationGain', async (t) => {
   await Promise.all(
     infoGainTests.map((tc, i) =>
       t.test(`${i}`, () => {
-        const actual = maxInformationGain(tc.numStates, tc.epsilon)
+        const actual = maxInformationGain(
+          tc.numStates,
+          tc.epsilon,
+          tc.attributionScopeLimit ?? 1,
+          constants.defaultMaxEventStates
+        )
         assert.deepStrictEqual(actual, tc.expected)
       })
     )
@@ -117,6 +140,8 @@ function defaultConfig(sourceType: SourceType): Config {
     constants.defaultEventLevelAttributionsPerSource[sourceType]
   return new Config(
     /*maxEventLevelReports=*/ defaultMaxReports,
+    /*attributionScopeLimit=*/ 1,
+    constants.defaultMaxEventStates,
     new Array(Number(constants.defaultTriggerDataCardinality[sourceType])).fill(
       new PerTriggerDataConfig(
         /*numWindows=*/
@@ -152,7 +177,7 @@ void test('computeConfigData', async (t) => {
       ),
       {
         numStates: 3,
-        infoGain: 1.584926511508231,
+        infoGain: 1.5849265115082316,
         flipProb: 0.000002494582008677539,
       }
     )

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -5,7 +5,7 @@ import { Maybe } from './maybe'
 import { serializeSource } from './to-json'
 import {
   Source,
-  SummaryWindowOperator,
+  SummaryOperator,
   TriggerDataMatching,
   validateSource,
 } from './validate-json'
@@ -72,7 +72,7 @@ const testCases: TestCase[] = [
             endTimes: [3601],
           },
           summaryBuckets: [1, 2],
-          summaryWindowOperator: SummaryWindowOperator.count,
+          summaryOperator: SummaryOperator.count,
           triggerData: new Set([0, 1, 2, 3, 4, 5, 6, 7]),
         },
       ],
@@ -2357,35 +2357,35 @@ const testCases: TestCase[] = [
     ],
   },
   {
-    name: 'summary-window-operator-wrong-type',
+    name: 'summary-operator-wrong-type',
     json: `{
       "destination": "https://a.test",
       "trigger_specs": [{
         "trigger_data": [3],
-        "summary_window_operator": 4
+        "summary_operator": 4
       }]
     }`,
     parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'summary_window_operator'],
+        path: ['trigger_specs', 0, 'summary_operator'],
         msg: 'must be a string',
       },
     ],
   },
   {
-    name: 'summary-window-operator-wrong-value',
+    name: 'summary-operator-wrong-value',
     json: `{
       "destination": "https://a.test",
       "trigger_specs": [{
         "trigger_data": [3],
-        "summary_window_operator": "VALUE_SUM"
+        "summary_operator": "VALUE_SUM"
       }]
     }`,
     parseFullFlex: true,
     expectedErrors: [
       {
-        path: ['trigger_specs', 0, 'summary_window_operator'],
+        path: ['trigger_specs', 0, 'summary_operator'],
         msg: 'must be one of the following (case-sensitive): count, value_sum',
       },
     ],

--- a/ts/src/header-validator/source.test.ts
+++ b/ts/src/header-validator/source.test.ts
@@ -2654,6 +2654,42 @@ const testCases: TestCase[] = [
     ],
   },
   {
+    name: 'invalid-attribution-scope-limit-attribution-scopes',
+    json: `{
+      "destination": "https://a.test",
+      "attribution_scopes": ["1"],
+      "attribution_scope_limit": true
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be a number',
+      },
+      {
+        path: ['attribution_scopes'],
+        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+      },
+    ],
+  },
+  {
+    name: 'invalid-attribution-scope-limit-amx-event-states',
+    json: `{
+      "destination": "https://a.test",
+      "max_event_states": 1,
+      "attribution_scope_limit": true
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scope_limit'],
+        msg: 'must be a number',
+      },
+      {
+        path: ['max_event_states'],
+        msg: 'cannot be fully validated without a valid attribution_scope_limit',
+      },
+    ],
+  },
+  {
     name: 'max-event-states-negative',
     json: `{
       "destination": "https://a.test",

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -105,7 +105,7 @@ function serializeTriggerData(d: Set<number>): TriggerData {
 export type TriggerSpec = EventReportWindows &
   TriggerData & {
     summary_buckets: number[]
-    summary_window_operator: string
+    summary_operator: string
   }
 
 function serializeTriggerSpec(ts: parsed.TriggerSpec): TriggerSpec {
@@ -114,7 +114,7 @@ function serializeTriggerSpec(ts: parsed.TriggerSpec): TriggerSpec {
     ...serializeTriggerData(ts.triggerData),
 
     summary_buckets: Array.from(ts.summaryBuckets),
-    summary_window_operator: ts.summaryWindowOperator,
+    summary_operator: ts.summaryOperator,
   }
 }
 

--- a/ts/src/header-validator/to-json.ts
+++ b/ts/src/header-validator/to-json.ts
@@ -182,6 +182,9 @@ export type Source = CommonDebug &
     source_event_id: string
     trigger_data_matching: string
     aggregatable_debug_reporting?: SourceAggregatableDebugReportingConfig
+    attribution_scopes: string[]
+    attribution_scope_limit?: number
+    max_event_states: number
   }
 
 export function serializeSource(s: parsed.Source, fullFlex: boolean): Source {
@@ -217,6 +220,9 @@ export function serializeSource(s: parsed.Source, fullFlex: boolean): Source {
       s.aggregatableDebugReporting,
       (v) => serializeSourceAggregatableDebugReportingConfig(v)
     ),
+    attribution_scopes: Array.from(s.attributionScopes),
+    ...ifNotNull('attribution_scope_limit', s.attributionScopeLimit, (v) => v),
+    max_event_states: s.maxEventStates,
   }
 }
 
@@ -347,6 +353,7 @@ export type Trigger = CommonDebug &
     event_trigger_data: EventTriggerDatum[]
     trigger_context_id?: string
     aggregatable_debug_reporting?: AggregatableDebugReportingConfig
+    attribution_scopes: string[]
   }
 
 export function serializeTrigger(
@@ -389,5 +396,6 @@ export function serializeTrigger(
       t.aggregatableDebugReporting,
       (v) => serializeAggregatableDebugReportingConfig(v)
     ),
+    attribution_scopes: Array.from(t.attributionScopes),
   }
 }

--- a/ts/src/header-validator/trigger.test.ts
+++ b/ts/src/header-validator/trigger.test.ts
@@ -50,7 +50,8 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           "key_piece": "0x5",
           "value": 123
         }]
-      }
+      },
+      "attribution_scopes": ["1"]
     }`,
     expected: Maybe.some({
       aggregatableDedupKeys: [
@@ -150,6 +151,7 @@ const testCases: jsontest.TestCase<Trigger>[] = [
           map: new Map([['g', new Set()]]),
         },
       ],
+      attributionScopes: new Set('1'),
     }),
   },
   {
@@ -1622,6 +1624,36 @@ const testCases: jsontest.TestCase<Trigger>[] = [
       {
         path: ['aggregatable_debug_reporting', 'debug_data'],
         msg: 'duplicate type: unspecified',
+      },
+    ],
+  },
+
+  // Attribution Scope
+  {
+    name: 'attribution-scope-not-string',
+    json: `{"attribution_scopes": [1]}`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes', 0],
+        msg: 'must be a string',
+      },
+    ],
+  },
+  {
+    name: 'attribution-scopes-empty-list',
+    json: `{
+      "attribution_scopes": []
+    }`,
+  },
+  {
+    name: 'attribution-scopes-not-list',
+    json: `{
+      "attribution_scopes": 1
+    }`,
+    expectedErrors: [
+      {
+        path: ['attribution_scopes'],
+        msg: 'must be a list',
       },
     ],
   },

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -759,7 +759,7 @@ function channelCapacity(s: Source, ctx: SourceContext): void {
   }
 }
 
-export enum SummaryWindowOperator {
+export enum SummaryOperator {
   count = 'count',
   value_sum = 'value_sum',
 }
@@ -767,7 +767,7 @@ export enum SummaryWindowOperator {
 export type TriggerSpec = {
   eventReportWindows: EventReportWindows
   summaryBuckets: number[]
-  summaryWindowOperator: SummaryWindowOperator
+  summaryOperator: SummaryOperator
   triggerData: Set<number>
 }
 
@@ -887,10 +887,10 @@ function triggerSpec(
       deps.maxEventLevelReports
     ),
 
-    summaryWindowOperator: field(
-      'summary_window_operator',
-      withDefault(enumerated, SummaryWindowOperator.count),
-      SummaryWindowOperator
+    summaryOperator: field(
+      'summary_operator',
+      withDefault(enumerated, SummaryOperator.count),
+      SummaryOperator
     ),
 
     triggerData: field('trigger_data', required(triggerDataSet)),
@@ -954,7 +954,7 @@ function triggerSpecsFromTriggerData(
         summaryBuckets: makeDefaultSummaryBuckets(
           deps.maxEventLevelReports.value
         ),
-        summaryWindowOperator: SummaryWindowOperator.count,
+        summaryOperator: SummaryOperator.count,
         triggerData: triggerData,
       },
     ]
@@ -974,7 +974,7 @@ function defaultTriggerSpecs(
           { length: maxEventLevelReports },
           (_, i) => i + 1
         ),
-        summaryWindowOperator: SummaryWindowOperator.count,
+        summaryOperator: SummaryOperator.count,
         triggerData: new Set(
           Array.from(
             {

--- a/ts/src/header-validator/validate-json.ts
+++ b/ts/src/header-validator/validate-json.ts
@@ -723,6 +723,8 @@ function channelCapacity(s: Source, ctx: SourceContext): void {
 
   const config = new privacy.Config(
     s.maxEventLevelReports,
+    s.attributionScopeLimit ?? 1,
+    s.maxEventStates,
     perTriggerDataConfigs
   )
 


### PR DESCRIPTION
The current attribution logic in the Attribution Reporting API may not be ideal for use-cases where an ad-tech needs more fine grain control over the attribution granularity (i.e. campaign, product, conversion ID, etc.) before a source is chosen for attribution. Currently available features such as top-level filters are not fully sufficient for this use-case because they happen after a source has been selected (i.e. after attribution). We can optionally support this use-case by allowing callers of the API to specify predefined attribution scopes that will be considered for filtering before attributing a source, in order to more efficiently extract utility out of the API.

This PR covers the information gain computation logic.